### PR TITLE
Added Jitsi server url setting

### DIFF
--- a/vector/src/main/java/im/vector/app/features/call/conference/JitsiService.kt
+++ b/vector/src/main/java/im/vector/app/features/call/conference/JitsiService.kt
@@ -26,6 +26,7 @@ import im.vector.app.features.call.conference.jwt.JitsiJWTFactory
 import im.vector.app.features.displayname.getBestName
 import im.vector.app.features.raw.wellknown.getElementWellknown
 import im.vector.app.features.settings.VectorLocaleProvider
+import im.vector.app.features.settings.VectorPreferences
 import im.vector.app.features.themes.ThemeProvider
 import okhttp3.Request
 import org.jitsi.meet.sdk.JitsiMeetUserInfo
@@ -50,6 +51,7 @@ class JitsiService @Inject constructor(
         private val jitsiJWTFactory: JitsiJWTFactory,
         private val clock: Clock,
         private val vectorLocale: VectorLocaleProvider,
+        private val vectorPreferences: VectorPreferences,
 ) {
 
     companion object {
@@ -69,7 +71,7 @@ class JitsiService @Inject constructor(
             rawService.getElementWellknown(session.sessionParams)
                     ?.jitsiServer
                     ?.preferredDomain
-        }
+        } ?: vectorPreferences.jitsiServerUrl()
         val jitsiDomain = preferredJitsiDomain ?: stringProvider.getString(R.string.preferred_jitsi_domain)
         val jitsiAuth = getJitsiAuth(jitsiDomain)
         val confId = createConferenceId(roomId, jitsiAuth)

--- a/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
@@ -766,6 +766,19 @@ class VectorPreferences @Inject constructor(
         return defaultPrefs.getBoolean(SETTINGS_CALL_PREVENT_ACCIDENTAL_CALL_KEY, false)
     }
 
+
+    /**
+     * Get the Jitsi server address for mesh network.
+     */
+
+    fun jitsiServerUrl(): String? {
+        var jitsiAddress = defaultPrefs.getString("SETTINGS_CALL_JITSI_SERVER_URL_KEY", "")
+        if (jitsiAddress!!.trim()=="") {
+            return null
+        }
+        return jitsiAddress
+    }
+
     /**
      * Tells if the read receipts should be shown.
      *

--- a/vector/src/main/res/xml/vector_settings_voice_video.xml
+++ b/vector/src/main/res/xml/vector_settings_voice_video.xml
@@ -10,6 +10,12 @@
             android:summary="@string/settings_call_show_confirmation_dialog_summary"
             android:title="@string/settings_call_show_confirmation_dialog_title" />
 
+        <im.vector.app.core.preference.VectorEditTextPreference
+            android:defaultValue=""
+            android:key="SETTINGS_CALL_JITSI_SERVER_URL_KEY"
+            android:title="Jitsi server address for mesh network"
+            app:useSimpleSummaryProvider="true" />
+
         <im.vector.app.core.preference.VectorSwitchPreference
             android:defaultValue="true"
             android:disableDependentsState="true"


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Added Jitsi Server URL configuration in the setting menu
## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
P2P Dendrite server does not give Jitsi server information properly. So made user to change it.
## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/vector-im/element-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/vector-im/element-android/blob/main/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt#L73)
